### PR TITLE
 Skip file transform if already AMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-es2015-modules-requirejs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Babel plugin to transform ES2015 modules to AMD using RequireJS's common JS wrapper.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,22 @@ export default function ({ Plugin, types: t }) {
     visitor: {
       Program: {
         exit(path) {
+
+          let isAmdModule = false;
+
+          path.traverse({
+              CallExpression({ node }) {
+                  if (node.callee && node.callee.name === 'define') {
+                    isAmdModule = true;
+                  }
+              }
+          });
+
+          // no point in wrapping something that's already AMD
+          if (isAmdModule) {
+            return;
+          }
+
           let body = templ({
             BODY: path.node.body
           });

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,11 @@
 var assert = require('assert');
 var babel = require('babel-core');
 
-describe('Transform', function() {
-  it('should wrap body in commonJS wrapper', function() {
-    const es6ModuleCode = 'export var foo = 1;';
-    const expected =`define(function (require, exports, module) {
+describe('Transform', function () {
+
+	it('should wrap body in commonJS wrapper', function () {
+		const es6ModuleCode = 'export var foo = 1;';
+		const expected = `define(function (require, exports, module) {
   "use strict";
 
   Object.defineProperty(exports, "__esModule", {
@@ -13,10 +14,22 @@ describe('Transform', function() {
   var foo = exports.foo = 1;
 });`;
 
-    var actual = babel.transform(es6ModuleCode, {
-      plugins: ['./lib/index.js']
-    }).code;
+		var actual = babel.transform(es6ModuleCode, {
+			plugins: ['./lib/index.js']
+		}).code;
 
-    assert.equal(actual, expected);
-  });
+		assert.equal(actual, expected);
+	});
+
+	it('does not modify an AMD module', function () {
+		let amdModule = 'define(function (require) {});';
+		let expected = '"use strict";\n\ndefine(function (require) {});';
+
+		let actual = babel.transform(amdModule, {
+			plugins: ['./lib/index.js']
+		}).code;
+
+		assert.equal(actual, expected);
+	});
+
 });


### PR DESCRIPTION
- Allows developers to slowly transition to `es6` format if entire project is AMD